### PR TITLE
Update runtime to 24.08 & use included libevent

### DIFF
--- a/com.teamspeak.TeamSpeak3.yaml
+++ b/com.teamspeak.TeamSpeak3.yaml
@@ -2,7 +2,7 @@ app-id: com.teamspeak.TeamSpeak3
 tags:
   - proprietary
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: teamspeak3
 finish-args:
@@ -15,12 +15,6 @@ finish-args:
   - --filesystem=xdg-download
   - --env=SSL_CERT_DIR=/etc/ssl/certs
 modules:
-  - name: libevent
-    buildsystem: cmake
-    sources:
-      - type: archive
-        url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
-        sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
   - name: teamspeak3
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
The runtime now includes libevent on its own:
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/libevent.bst?ref_type=heads